### PR TITLE
Update documentation url in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Onboarding to Bitcoin Core
 
-This documentation is currently hosted at https://bitcoincore.wtf[bitcoincore.wtf] however this location may be subject to change in the future.
+This documentation is currently hosted at https://bitcoincore.academy[https://bitcoincore.academy] however this location may be subject to change in the future.
 
 See https://github.com/chaincodelabs/onboarding-to-bitcoin-core/blob/master/asciidoc_workflow.adoc[asciidoc_workflow.adoc] 
 and https://github.com/chaincodelabs/onboarding-to-bitcoin-core/blob/master/jekyll_workflow.md[jekyll_workflow.md] for tips on contributing and instructions for running locally.


### PR DESCRIPTION
I found this project through https://bitcoindevs.xyz/bitcoin-core and saw the github README was out of date